### PR TITLE
Add support for finding and selecting editor path

### DIFF
--- a/src/EditorFinder.cs
+++ b/src/EditorFinder.cs
@@ -26,16 +26,14 @@ public static class EditorFinder
             }
             catch (JsonException)
             {
-                Console.WriteLine($"Error parsing {userPathFile}. Falling back to default path.");
+                Console.Error.WriteLine($"Error parsing {userPathFile}. Falling back to default path.");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error reading {userPathFile}: {ex.Message}. Falling back to default path.");
+                Console.Error.WriteLine($"Error reading {userPathFile}: {ex.Message}. Falling back to default path.");
             }
         }
 
-        // Use default as fallback
-        // this is the case most of the time I think
         var defaultPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
             "Unity", "Hub", "Editor");
@@ -72,7 +70,7 @@ public static class EditorFinder
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Error enumerating Unity installations: {ex.Message}");
+            Console.Error.WriteLine($"Error enumerating Unity installations: {ex.Message}");
         }
 
         return editorPaths;
@@ -91,11 +89,8 @@ public static class EditorFinder
         }
 
         Console.WriteLine("Select an editor to patch:");
-        // Console.WriteLine("Select an editor to patch. Ctrl+C to cancel:");
         for (var i = 0; i < editorPaths.Count; i++)
         {
-            // string versionInfo = Path.GetFileName(Path.GetDirectoryName(editorPaths[i]) ?? string.Empty);
-            // Console.WriteLine($"  [{i}] {versionInfo}");
             Console.WriteLine($"  [{i}] {editorPaths[i]}");
         }
 

--- a/src/EditorFinder.cs
+++ b/src/EditorFinder.cs
@@ -59,7 +59,7 @@ public static class EditorFinder
 
         try
         {
-            foreach (var dir in Directory.GetDirectories(rootPath))
+            foreach (var dir in Directory.EnumerateDirectories(rootPath))
             {
                 var editorExePath = Path.Combine(dir, "Editor", "Unity.exe");
                 if (File.Exists(editorExePath))

--- a/src/EditorFinder.cs
+++ b/src/EditorFinder.cs
@@ -1,0 +1,113 @@
+﻿using System.Text.Json;
+
+namespace UnityRoslynUpdater;
+
+public static class EditorFinder
+{
+    /// <summary>
+    /// First try parse Unity Hub secondaryInstallPath.json
+    /// If unspecified, then fall back to default path
+    /// </summary>
+    public static string GetEditorRoot()
+    {
+        var userPathFile = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "UnityHub", "secondaryInstallPath.json");
+
+        if (File.Exists(userPathFile))
+        {
+            try
+            {
+                var userPath = JsonDocument.Parse(File.ReadAllText(userPathFile)).RootElement.GetString() ?? string.Empty;
+                if (!string.IsNullOrEmpty(userPath) && Directory.Exists(userPath))
+                {
+                    return userPath;
+                }
+            }
+            catch (JsonException)
+            {
+                Console.WriteLine($"Error parsing {userPathFile}. Falling back to default path.");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error reading {userPathFile}: {ex.Message}. Falling back to default path.");
+            }
+        }
+
+        // Use default as fallback
+        // this is the case most of the time I think
+        var defaultPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+            "Unity", "Hub", "Editor");
+
+        if (Directory.Exists(defaultPath))
+        {
+            return defaultPath;
+        }
+
+        // No path found
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Gets all editor paths under Unity Hub installation root
+    /// </summary>
+    public static List<string> GetEditorFullPaths()
+    {
+        var editorPaths = new List<string>();
+
+        var rootPath = GetEditorRoot();
+        if (string.IsNullOrEmpty(rootPath)) return editorPaths; // return empty if root not found
+
+        try
+        {
+            foreach (var dir in Directory.GetDirectories(rootPath))
+            {
+                var editorExePath = Path.Combine(dir, "Editor", "Unity.exe");
+                if (File.Exists(editorExePath))
+                {
+                    editorPaths.Add(Path.GetFullPath(Path.Combine(dir, "Editor")));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error enumerating Unity installations: {ex.Message}");
+        }
+
+        return editorPaths;
+    }
+
+    /// <summary>
+    /// Let user choose from available installations by typing list index
+    /// </summary>
+    public static string ChooseEditorFullPath()
+    {
+        var editorPaths = GetEditorFullPaths();
+
+        if (editorPaths.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        Console.WriteLine("Select an editor to patch:");
+        // Console.WriteLine("Select an editor to patch. Ctrl+C to cancel:");
+        for (var i = 0; i < editorPaths.Count; i++)
+        {
+            // string versionInfo = Path.GetFileName(Path.GetDirectoryName(editorPaths[i]) ?? string.Empty);
+            // Console.WriteLine($"  [{i}] {versionInfo}");
+            Console.WriteLine($"  [{i}] {editorPaths[i]}");
+        }
+
+        while (true)
+        {
+            Console.Write("Enter index number: ");
+            if (int.TryParse(Console.ReadLine(), out var index) && index >= 0 && index < editorPaths.Count)
+            {
+                return editorPaths[index];
+            }
+
+            Console.WriteLine("Invalid selection. Please try again.");
+        }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -5,29 +5,34 @@ using AsmResolver.DotNet.Signatures;
 using AsmResolver.PE.DotNet.Cil;
 using UnityRoslynUpdater;
 
-if (args.Length < 1)
-{
-    Console.Error.WriteLine(
-        """
-        Please provide the path to the 'Editor' directory of the Unity
-        installation that you wish to link to a newer .NET SDK version.
-        """);
+const string errorMsg =
+    """
+    Please provide the path to the 'Editor' directory of the Unity
+    installation that you wish to link to a newer .NET SDK version.
+    """;
 
-    return;
+string editorPath;
+
+if (args.Length >= 1)
+{
+    editorPath = Path.GetFullPath(args[0]);
+}
+else
+{
+    editorPath = EditorFinder.ChooseEditorFullPath();
+
+    if (string.IsNullOrEmpty(editorPath))
+    {
+        Console.Error.WriteLine(errorMsg);
+        return;
+    }
 }
 
-var editorPath = Path.GetFullPath(args[0]);
 var dataPath = Path.Combine(editorPath, "Data");
 
 if (!Directory.Exists(dataPath))
 {
-    Console.Error.WriteLine(
-        """
-        The 'Data' directory could not be located. Please provide the
-        path to the 'Editor' directory of the Unity installation that
-        you wish to link to a newer .NET SDK version.
-        """);
-
+    Console.Error.WriteLine(errorMsg);
     return;
 }
 


### PR DESCRIPTION
<img width="854" alt="25 05 07_22 04 44" src="https://github.com/user-attachments/assets/0f732c37-e600-4f92-aa73-99dda65bfd41" />

I add fallback to the args handling, so that if user run the program with no argument, they can interactively select a path.

The new `EditorFinder` static class was ported from this [powershell snippet](https://gist.github.com/Maoyeedy/d212f38730348d2dbe6e1d2abdde21ab) I wrote.
